### PR TITLE
smarthome-6828: Make sure to subscribe to the channels after restart

### DIFF
--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/Property.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/convention/homie300/Property.java
@@ -254,6 +254,8 @@ public class Property implements AttributeChanged {
             f.completeExceptionally(new IllegalStateException("Attributes not yet received!"));
             return f;
         }
+        // Make sure we set the callback again which might have been nulled during an stop
+        channelState.setChannelStateUpdateListener(this.callback);
         return channelState.start(connection, scheduler, timeout);
     }
 

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/generic/ChannelState.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/generic/ChannelState.java
@@ -141,7 +141,7 @@ public class ChannelState implements MqttMessageSubscriber {
     public void processMessage(String topic, byte[] payload) {
         final ChannelStateUpdateListener channelStateUpdateListener = this.channelStateUpdateListener;
         if (channelStateUpdateListener == null) {
-            logger.warn("MQTT message received, but MessageSubscriber object hasn't been started!", topic);
+            logger.warn("MQTT message received for topic {}, but MessageSubscriber object hasn't been started!", topic);
             return;
         }
 
@@ -293,6 +293,7 @@ public class ChannelState implements MqttMessageSubscriber {
         this.future = new CompletableFuture<>();
         connection.subscribe(config.stateTopic, this).thenRun(() -> {
             hasSubscribed = true;
+            logger.debug("Subscribed channel {} to topic: {}", this.channelUID, config.stateTopic);
             if (timeout > 0 && !future.isDone()) {
                 this.scheduledFuture = scheduler.schedule(this::receivedOrTimeout, timeout, TimeUnit.MILLISECONDS);
             } else {

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomieThingHandler.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomieThingHandler.java
@@ -186,7 +186,7 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
 
     /**
      * Callback of {@link DelayedBatchProcessing}.
-     * Add all newly discovered nodes and properties to the Thing.
+     * Add all newly discovered nodes and properties to the Thing and start subscribe to each channel state topic.
      */
     @Override
     public void accept(@Nullable List<Object> t) {
@@ -198,5 +198,11 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
                 .map(prop -> prop.getChannel()).collect(Collectors.toList());
         updateThing(editThing().withChannels(channels).build());
         updateProperty(MqttBindingConstants.HOMIE_PROPERTY_VERSION, device.attributes.homie);
+        final MqttBrokerConnection connection = this.connection;
+        if (connection != null) {
+            device.startChannels(connection, scheduler, attributeReceiveTimeout, this).thenRun(() -> {
+                logger.trace("Homie device {} fully attached", device.attributes.name);
+            });
+        }
     }
 }

--- a/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomieThingHandler.java
+++ b/addons/binding/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/HomieThingHandler.java
@@ -198,5 +198,11 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
                 .map(prop -> prop.getChannel()).collect(Collectors.toList());
         updateThing(editThing().withChannels(channels).build());
         updateProperty(MqttBindingConstants.HOMIE_PROPERTY_VERSION, device.attributes.homie);
+        final MqttBrokerConnection connection = this.connection;
+        if (connection != null) {
+            device.startChannels(connection, scheduler, attributeReceiveTimeout, this).thenRun(() -> {
+                logger.trace("Homie device {} fully attached", device.attributes.name);
+            });
+        }
     }
 }


### PR DESCRIPTION
… accept() but rather in the start() method. The latter is also triggered right after the initalization (eg. after a restart)

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific addon: Mention the addon shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the addon README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It's a good practice to add an URL to your built JAR in this Pull Request description,
so it's easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it's reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
